### PR TITLE
Add Unit Tests for calculate_detected_at Helper

### DIFF
--- a/backend/tests/test_audio_analyzer.py
+++ b/backend/tests/test_audio_analyzer.py
@@ -1,0 +1,22 @@
+# backend/tests/test_audio_analyzer.py
+
+import pytest
+from backend.services.audio_analyzer import calculate_detected_at
+
+def test_calculate_detected_at_valid():
+    filename = "20231001_123456.WAV"
+    start_sec = 10.0
+    expected_result = "2023-10-01T12:35:06" 
+    result = calculate_detected_at(filename, start_sec)
+    assert result == expected_result
+
+def test_calculate_detected_at_invalid_filename():
+    with pytest.raises(ValueError, match="Invalid filename format"):
+        calculate_detected_at("invalid_filename.wav", 10.0)
+
+def test_calculate_detected_at_zero_seconds():
+    filename = "20231001_123456.WAV"
+    start_sec = 0.0
+    expected_result = "2023-10-01T12:34:56"  # Exact time from filename
+    result = calculate_detected_at(filename, start_sec)
+    assert result == expected_result

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ httpx==0.28.1
 idna==3.10
 importlib_metadata==8.6.1
 importlib_resources==6.5.2
+iniconfig==2.1.0
 jiter==0.9.0
 joblib==1.4.2
 keras==3.9.2
@@ -68,6 +69,7 @@ packaging==25.0
 pathspec==0.12.1
 pillow==11.2.1
 platformdirs==4.3.7
+pluggy==1.6.0
 pooch==1.8.2
 propcache==0.3.1
 protobuf==5.29.4
@@ -80,6 +82,7 @@ pydantic_core==2.33.1
 pydub==0.25.1
 Pygments==2.19.1
 pyparsing==3.2.3
+pytest==8.3.5
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.0
 python-multipart==0.0.20


### PR DESCRIPTION
This PR adds unit tests for the calculate_detected_at() function. These tests ensure the helper function reliably parses timestamps from filenames and handles edge cases correctly. Closes #38 

### What's Included

- `test_calculate_detected_at_valid`: confirms correct timestamp generation from a valid filename and start seconds  
- `test_calculate_detected_at_zero_seconds`: checks behavior when `start_sec` is zero  
- `test_calculate_detected_at_invalid_filename`: verifies that invalid filenames raise a `ValueError`  
- `requirements.txt` updated to include `pytest` and other test dependencies