### PR TITLE
Refactor Audio Analyzer for API Integration and Preload Analyzer Globally 

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,13 +1,23 @@
 # main.py
 from fastapi import FastAPI
+from birdnetlib.analyzer import Analyzer
 from backend.app.routes.analyze import router as analyze_router
 from backend.app.routes.detections import router as detections_router
 from database.config import Base, engine
 from backend.app.models.detection import Detections
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
 
 # Initialize FastAPI app
 app = FastAPI()
 
+@app.on_event("startup")
+async def load_analyzer():
+    app.state.analyzer = Analyzer()
 
 # Root endpoint
 @app.get("/")

--- a/backend/app/routes/analyze.py
+++ b/backend/app/routes/analyze.py
@@ -1,24 +1,60 @@
-from fastapi import APIRouter, HTTPException, UploadFile, File
+from fastapi import APIRouter, UploadFile, File, Form, Request, HTTPException
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from pathlib import Path
+import zipfile
 from typing import List
+import logging
+from backend.services.audio_analyzer import analyze_audio_file
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.post("/analyze")
-async def analyze_upload(files: list[UploadFile] = File(...)):
-    """
-    Endpoint to analyze uploaded audio files.
-    Args:
-        files (list[UploadFile]): List of audio files to analyze.
-    Returns:
-        dict: Analysis results for each file.
-    """
-    if not files:
-        raise HTTPException(status_code=400, detail="No files provided")
+async def analyze_audio(
+    request: Request,
+    file: UploadFile = File(...),
+    lat: float = Form(...),
+    lon: float = Form(...),
+):
+    analyzer = request.app.state.analyzer
+    filename = file.filename.lower()
 
-    results = []
-    for file in files:
-        # Placeholder: Here you would save and analyze the file
-        results.append({"filename": file.filename, "status": "processed"})
+    if filename.endswith(".wav"):
+        with NamedTemporaryFile(delete=True, suffix=".wav") as tmp:
+            contents = await file.read()
+            tmp.write(contents)
+            tmp.flush()
+            tmp_path = Path(tmp.name)
+            original_filename = file.filename
+            tmp_path_with_name = tmp_path.with_name(original_filename)
+            tmp_path.rename(tmp_path_with_name)
+            logger.info(f"Analyzing uploaded file: {original_filename}")
 
-    return {"results": results}
+            detections = analyze_audio_file(tmp_path_with_name, analyzer, lat, lon)
+            return {"detections": detections}
+
+    elif filename.endswith(".zip"):
+        with TemporaryDirectory() as tmpdir:
+            tmp_zip_path = Path(tmpdir) / filename
+            with open(tmp_zip_path, "wb") as out:
+                out.write(await file.read())
+
+            try:
+                with zipfile.ZipFile(tmp_zip_path, "r") as zip_ref:
+                    zip_ref.extractall(tmpdir)
+            except zipfile.BadZipFile:
+                raise HTTPException(status_code=400, detail="Invalid ZIP file")
+
+            all_detections = []
+            for wav_file in Path(tmpdir).rglob("*.wav"):
+                try:
+                    results = analyze_audio_file(wav_file, analyzer, lat, lon)
+                    all_detections.extend(results)
+                except Exception as e:
+                    logger.warning(f"Skipping {wav_file.name}: {e}")
+
+            return {"detections": all_detections}
+
+    else:
+        raise HTTPException(status_code=400, detail="Only .WAV and .ZIP files are supported")

--- a/backend/app/routes/analyze.py
+++ b/backend/app/routes/analyze.py
@@ -30,7 +30,6 @@ async def analyze_audio(
             tmp_path_with_name = tmp_path.with_name(original_filename)
             tmp_path.rename(tmp_path_with_name)
             logger.info(f"Analyzing uploaded file: {original_filename}")
-
             detections = analyze_audio_file(tmp_path_with_name, analyzer, lat, lon)
             return {"detections": detections}
 
@@ -47,7 +46,11 @@ async def analyze_audio(
                 raise HTTPException(status_code=400, detail="Invalid ZIP file")
 
             all_detections = []
-            for wav_file in Path(tmpdir).rglob("*.wav"):
+            
+            wav_files = list(Path(tmpdir).rglob("*.[wW][aA][vV]"))
+            logger.info(f"Found {len(wav_files)} wav files in ZIP archive")
+
+            for wav_file in wav_files:
                 try:
                     results = analyze_audio_file(wav_file, analyzer, lat, lon)
                     all_detections.extend(results)

--- a/backend/services/audio_analyzer.py
+++ b/backend/services/audio_analyzer.py
@@ -6,6 +6,7 @@ import json
 import csv
 import time
 from pathlib import Path
+from typing import List, Dict, Any
 from datetime import datetime, timedelta
 from tqdm import tqdm
 import re
@@ -30,7 +31,8 @@ def calculate_detected_at(filename: str, start_sec: float) -> str:
     date_str, time_str = match.groups()
     start_dt = datetime.strptime(f"{date_str}{time_str}", "%Y%m%d%H%M%S")
     detected_dt = start_dt + timedelta(seconds=start_sec)
-    return detected_dt.isoformat()
+    return detected_dt.replace(microsecond=0).isoformat()
+
 
 def analyze_audio_file(
     file_path: Path,

--- a/backend/services/audio_analyzer.py
+++ b/backend/services/audio_analyzer.py
@@ -91,8 +91,8 @@ def analyze_audio_file(
 def analyze_audio_directory(
     directory_path: Path,
     analyzer: Analyzer,
-    lat=48.52,
-    lon=-123.40,
+    lat: float,
+    lon: float,
     output_dir="./outputs",
     output_name="predictions",
 ):

--- a/backend/services/audio_analyzer.py
+++ b/backend/services/audio_analyzer.py
@@ -10,7 +10,9 @@ from typing import List, Dict, Any
 from datetime import datetime, timedelta
 from tqdm import tqdm
 import re
+import logging
 
+logger = logging.getLogger(__name__)
 
 def calculate_detected_at(filename: str, start_sec: float) -> str:
     """
@@ -85,7 +87,7 @@ def analyze_audio_file(
             }
             results.append(result)
         except Exception as e:
-            print(f"Error saving detection for {file_path.name}: {e}")
+            logger.exception(f"Error saving detection for {file_path.name}")
     return results
 
 def analyze_audio_directory(
@@ -117,22 +119,22 @@ def analyze_audio_directory(
 
     all_results = []
 
-    print(f"[INFO] Found {len(wav_files)} audio files in '{directory_path}'")
-    print(f"[INFO] Using lat={lat}, lon={lon}")
-    print(f"[INFO] Output will be saved to '{output_dir}'\n")
+    logger.info(f"Found {len(wav_files)} audio files in '{directory_path}'")
+    logger.info(f"Using lat={lat}, lon={lon}")
+    logger.info(f"Output will be saved to '{output_dir}'\n")
 
     start_total = time.time()
 
     for idx, wav_file in enumerate(tqdm(wav_files, desc="Analyzing audio files", unit="file"), 1):
-        print(f"[{idx}/{len(wav_files)}] Analyzing '{wav_file.name}'...")
+        logger.info(f"[{idx}/{len(wav_files)}] Analyzing '{wav_file.name}'...")
         try:
             detections = analyze_audio_file(wav_file, analyzer, lat, lon)
-            print(f"Detections for {wav_file.name}: {len(detections)}")
+            logger.info(f"Detections for {wav_file.name}: {len(detections)}")
             if detections:
-                print("Sample detection:", detections[0])
+                logger.debug("Sample detection:", detections[0])
             all_results.extend(detections)
         except Exception as e:
-            print(f"Error analyzing '{wav_file.name}': {e}\n")
+            logger.exception(f"Error analyzing '{wav_file.name}': {e}\n")
 
     # Save all results
     json_path = Path(output_dir) / f"{output_name}.json"
@@ -158,7 +160,7 @@ def analyze_audio_directory(
         writer.writerows(all_results)
 
     total_time = time.time() - start_total
-    print(f"[INFO] Analysis complete. {len(all_results)} predictions saved.")
-    print(f" - JSON: {json_path}")
-    print(f" - CSV:  {csv_path}")
-    print(f"[INFO] Total time: {total_time:.2f}s")
+    logger.info(f"[INFO] Analysis complete. {len(all_results)} predictions saved.")
+    logger.info(f" - JSON: {json_path}")
+    logger.info(f" - CSV:  {csv_path}")
+    logger.info(f"[INFO] Total time: {total_time:.2f}s")

--- a/backend/tests/test_audio_analyzer.py
+++ b/backend/tests/test_audio_analyzer.py
@@ -1,7 +1,15 @@
 # backend/tests/test_audio_analyzer.py
 
 import pytest
-from backend.services.audio_analyzer import calculate_detected_at
+from pathlib import Path
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+from typing import List, Dict, Any
+from backend.services.audio_analyzer import (
+    calculate_detected_at,
+    analyze_audio_file,
+)
+from birdnetlib.analyzer import Analyzer
 
 def test_calculate_detected_at_valid():
     filename = "20231001_123456.WAV"
@@ -20,3 +28,30 @@ def test_calculate_detected_at_zero_seconds():
     expected_result = "2023-10-01T12:34:56"  # Exact time from filename
     result = calculate_detected_at(filename, start_sec)
     assert result == expected_result
+
+@patch("backend.services.audio_analyzer.Recording")
+def test_analyze_audio_file_mocked(mock_recording_class):
+    mock_recording = MagicMock()
+    mock_recording.detections = [
+        {
+            "start_time": 12.3,
+            "end_time": 14.5,
+            "common_name": "Raven",
+            "scientific_name": "Corvus corax",
+            "label": "RAVN",
+            "confidence": 0.85,
+        }
+    ]
+    mock_recording_class.return_value = mock_recording
+
+    analyzer = MagicMock()
+    file_path = Path("tests/data/20231001_123456.WAV")
+    lat, lon = 48.52, -123.40
+
+    results = analyze_audio_file(file_path, analyzer, lat, lon)
+
+    assert isinstance(results, list)
+    assert len(results) == 1
+    assert results[0]["species"] == "Raven"
+    assert results[0]["confidence"] == 0.85
+    assert results[0]["detected_at"] == "2023-10-01T12:35:08"


### PR DESCRIPTION
This PR closes #8 by refactoring the audio analysis flow, preloading the BirdNET model on app startup, and integrating real audio analysis into the /analyze endpoint.

Changes Implemented

- Refactored `analyze_audio_file()` as a callable for analyzing individual `.wav` files
- Preloaded a global `Analyzer()` instance using FastAPI’s `@app.on_event("startup")`
- Created a `/api/analyze` POST endpoint that:
  - Accepts a single `.wav` or `.zip` file via `multipart/form-data`
  - Requires `lat` and `lon` as form fields (no fallbacks)
  - Renames temp `.wav` files to preserve timestamp parsing
  - Returns all detections in JSON format
- Replaced `print()` statements in `audio_analyzer.py` with `logger` calls
- Wrote test coverage for `calculate_detected_at()` and `analyze_audio_file()` using mocks
- Validated in Swagger UI with both `.wav` and `.zip` files