### PR TITLE
Rename calculate_detected_at to calculate_detection_time for consiste…

### DIFF
--- a/backend/services/audio_analyzer.py
+++ b/backend/services/audio_analyzer.py
@@ -36,7 +36,7 @@ def get_recording_datetime(filename:str) -> datetime:
     date_str, time_str = match.groups()
     return datetime.strptime(f"{date_str}{time_str}", "%Y%m%d%H%M%S")
 
-def calculate_detected_at(filename: str, start_sec: float) -> datetime:
+def calculate_detection_time(filename: str, start_sec: float) -> datetime:
     """
     Calculates the actual time a detection occurred, based on the file name and start seconds.
 
@@ -91,7 +91,7 @@ def analyze_audio_file(
             start_sec = det.get("start_time", None)
             recording_datetime = get_recording_datetime(file_path.name)
             detection_time = (
-                calculate_detected_at(file_path.name, start_sec)
+                calculate_detection_time(file_path.name, start_sec)
                 if start_sec is not None else None
             )
 

--- a/backend/tests/test_audio_analyzer.py
+++ b/backend/tests/test_audio_analyzer.py
@@ -6,27 +6,27 @@ from datetime import datetime
 from unittest.mock import patch, MagicMock
 from typing import List, Dict, Any
 from backend.services.audio_analyzer import (
-    calculate_detected_at,
+    calculate_detection_time,
     analyze_audio_file,
 )
 from birdnetlib.analyzer import Analyzer
 
-def test_calculate_detected_at_valid():
+def test_calculate_detection_time_valid():
     filename = "20231001_123456.WAV"
     start_sec = 10.0
     expected_result = datetime(2023, 10, 1, 12, 35, 6)
-    result = calculate_detected_at(filename, start_sec)
+    result = calculate_detection_time(filename, start_sec)
     assert result == expected_result
 
-def test_calculate_detected_at_invalid_filename():
+def test_calculate_detection_time_invalid_filename():
     with pytest.raises(ValueError, match="Invalid filename format"):
-        calculate_detected_at("invalid_filename.wav", 10.0)
+        calculate_detection_time("invalid_filename.wav", 10.0)
 
-def test_calculate_detected_at_zero_seconds():
+def test_calculate_detection_time_zero_seconds():
     filename = "20231001_123456.WAV"
     start_sec = 0.0
     expected_result = datetime(2023, 10, 1, 12, 34, 56)
-    result = calculate_detected_at(filename, start_sec)
+    result = calculate_detection_time(filename, start_sec)
     assert result == expected_result
 
 @patch("backend.services.audio_analyzer.Recording")


### PR DESCRIPTION
The function name calculate_detected_at is inconsistent with the database field detection_time, which leads to confusion in the codebase. Renamed the function to calculate_detection_time for clarity and consistency.
Closes #50 