### PR TITLE
refactor: use create_detections() in analyze_audio_file

### DIFF
--- a/backend/app/routes/analyze.py
+++ b/backend/app/routes/analyze.py
@@ -58,6 +58,9 @@ async def analyze_audio(
             logger.info(f"Found {len(wav_files)} wav files in ZIP archive")
 
             for wav_file in wav_files:
+                if wav_file.name.startswith("._") or wav_file.name.startswith("."):
+                    logger.warning(f"Skipping macOS hidden file: {wav_file.name}")
+                    continue
                 try:
                     results = analyze_audio_file(wav_file, analyzer, lat, lon, db=db)
                     all_detections.extend(results)

--- a/backend/app/routes/analyze.py
+++ b/backend/app/routes/analyze.py
@@ -1,9 +1,13 @@
-from fastapi import APIRouter, UploadFile, File, Form, Request, HTTPException
-from tempfile import NamedTemporaryFile, TemporaryDirectory
-from pathlib import Path
-import zipfile
 import logging
+import zipfile
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
+from sqlalchemy.orm import Session
+
 from backend.services.audio_analyzer import analyze_audio_file
+from database.config import get_db
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -15,6 +19,7 @@ async def analyze_audio(
     file: UploadFile = File(...),
     lat: float = Form(...),
     lon: float = Form(...),
+    db: Session = Depends(get_db)
 ):
     analyzer = request.app.state.analyzer
     if not file.filename:
@@ -32,7 +37,7 @@ async def analyze_audio(
             tmp_path_with_name = tmp_path.with_name(original_filename)
             tmp_path.rename(tmp_path_with_name)
             logger.info(f"Analyzing uploaded file: {original_filename}")
-            detections = analyze_audio_file(tmp_path_with_name, analyzer, lat, lon)
+            detections = analyze_audio_file(tmp_path_with_name, analyzer, lat, lon, db=db)
             return {"detections": detections}
 
     elif filename.endswith(".zip"):
@@ -54,7 +59,7 @@ async def analyze_audio(
 
             for wav_file in wav_files:
                 try:
-                    results = analyze_audio_file(wav_file, analyzer, lat, lon)
+                    results = analyze_audio_file(wav_file, analyzer, lat, lon, db=db)
                     all_detections.extend(results)
                 except Exception as e:
                     logger.warning(f"Skipping {wav_file.name}: {e}")


### PR DESCRIPTION
This PR Closes #43 by refactoring `analyze_audio_file()` to use the existing `create_detections()` CRUD function instead of performing raw SQLAlchemy inserts. It also improves the `/analyze` route by skipping macOS system files (`._*.WAV`, `.DS_Store`).

## Changes

### Refactor analyze_audio_file()

- Added optional `db: Optional[Session]` parameter to `analyze_audio_file()`:
  - Uses passed-in `db` session (via FastAPI injection), or
  - Creates its own local session when run via CLI
- Replaced raw `db.add_all([...])` insert logic with a call to `create_detections()`
- Converts detection result dicts to `DetectionCreate` Pydantic models before insert

###  Update /analyze endpoint

- Injects `db` session using `Depends(get_db)`
- Passes `db` to `analyze_audio_file()` for both `.wav` and `.zip` inputs

###  Skip macOS metadata files in ZIP uploads

- Skips files starting with `._` or `.` during ZIP extraction
- Logs a warning for each skipped hidden/system file
- Prevents unnecessary parsing errors (e.g. `time data '.' does not match format '%Y%m%d'`)

## Results

- The system now properly uses the CRUD layer to persist detection results
- Uploads from macOS ZIP files no longer generate avoidable errors
- Both FastAPI and CLI usage of `analyze_audio_file()` are supported